### PR TITLE
Oro 4.1 Compatibility: RequireJS to JSModules Migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OroCommerce Bundle to add an ABN to the customer registration form and Customer Entity",
     "type": "project",
     "require": {
-        "oro/commerce": "4.*"
+        "oro/commerce": "4.1.*"
     },
     "autoload": {
         "psr-4": { "Aligent\\ABNBundle\\": "./src/" }

--- a/src/Resources/views/layouts/default/config/jsmodules.yml
+++ b/src/Resources/views/layouts/default/config/jsmodules.yml
@@ -1,0 +1,6 @@
+app-modules:
+  - aligentabn/js/app/modules/abn-module
+
+dynamic-imports:
+  oropricing:
+    - aligentabn/js/validator/abn

--- a/src/Resources/views/layouts/default/config/requirejs.yml
+++ b/src/Resources/views/layouts/default/config/requirejs.yml
@@ -1,6 +1,0 @@
-config:
-  paths:
-    'aligentabn/js/validator/abn': 'bundles/aligentabn/js/validator/abn.js'
-    'aligentabn/js/app/modules/abn-module': 'bundles/aligentabn/js/app/modules/abn-module.js'
-  appmodules:
-    - aligentabn/js/app/modules/abn-module


### PR DESCRIPTION
* Convert requirejs.yml to jsmodules.yml as missing part of 4.1 migration
* Lock composer.json to OroCommerce 4.1 as it is incompatible with 4.0

**Valid ABN**
![Selection_806](https://user-images.githubusercontent.com/45612883/74206479-92038e00-4ccb-11ea-921f-9e587af87c27.png)
**Invalid ABN**
![Selection_805](https://user-images.githubusercontent.com/45612883/74206482-9334bb00-4ccb-11ea-943e-591b5ee50125.png)
