### PR TITLE
4.2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Aligent ABN Bundle for OroCommerce
 
 Facts
 -----
-- version: 4.2.0 (Compatible with OroCommerce >=4.0)
+- version: 4.2.0 (Compatible with OroCommerce 4.2.*)
 - composer name: aligent/orocommerce-abn-bundle
 
 Description
@@ -28,7 +28,6 @@ Installation Instructions
 
 Developers
 ---------
-Jim O'Halloran <jim@aligent.com.au>
 Adam Hall <adam.hall@aligent.com.au>
 
 Licence

--- a/src/Form/Extension/RegistrationTypeExtension.php
+++ b/src/Form/Extension/RegistrationTypeExtension.php
@@ -33,7 +33,7 @@ class RegistrationTypeExtension extends AbstractTypeExtension
         if ($this->configManager->get(Configuration::getConfigKeyByName(Configuration::ENABLED), false)) {
             $builder->add('abn', ABNType::class, [
                     'label' => 'aligent.frontend.abn.label',
-                    'required' => $this->configManager->get(Configuration::getConfigKeyByName(Configuration::ABN_REQUIRED), false),
+                    'required' => $this->configManager->get(Configuration::getConfigKeyByName(Configuration::ABN_REQUIRED)),
                     'mapped' => false
                 ]);
 

--- a/src/Form/Type/CustomerGroupSelectType.php
+++ b/src/Form/Type/CustomerGroupSelectType.php
@@ -36,7 +36,7 @@ class CustomerGroupSelectType extends AbstractType
 
     public function getName()
     {
-        return 'alg_customer_customer_group_select';
+        return 'aligent_abn_customer_group_select';
     }
 
     /**

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,31 +1,18 @@
-parameters:
-  # Form Extensions
-  alg_abn.form.registration_form_type_extension.class: Aligent\ABNBundle\Form\Extension\RegistrationTypeExtension
-
-  # Form Subscribers
-  alg_abn.form.subscriber.frontend_customer_user_registration_subscriber.class: Aligent\ABNBundle\Form\EventListener\FrontendCustomerUserRegistrationTypeSubscriber
-
-  # Form Type
-  alg_abn.form.customer_group_select_type.class: Aligent\ABNBundle\Form\Type\CustomerGroupSelectType
-
 services:
-  alg_abn.form.registration_form_type_extension:
-    class: '%alg_abn.form.registration_form_type_extension.class%'
+  Aligent\ABNBundle\Form\Extension\RegistrationTypeExtension:
     calls:
       - [setConfigManager, ['@oro_config.manager']]
       - [setSubscriber, ['@alg_abn.form.subscriber.frontend_customer_user_registration_subscriber']]
     tags:
       - { name: form.type_extension, extended_type: Oro\Bundle\CustomerBundle\Form\Type\FrontendCustomerUserRegistrationType }
 
-  alg_abn.form.subscriber.frontend_customer_user_registration_subscriber:
-    class: '%alg_abn.form.subscriber.frontend_customer_user_registration_subscriber.class%'
+  Aligent\ABNBundle\Form\EventListener\FrontendCustomerUserRegistrationTypeSubscriber:
     arguments:
       - '@doctrine'
       - '@oro_config.manager'
 
-  alg_abn.form.customer_group_select_type:
-    class: '%alg_abn.form.customer_group_select_type.class%'
+  Aligent\ABNBundle\Form\Type\CustomerGroupSelectType:
     arguments:
       - '@doctrine'
     tags:
-        - { name: form.type, alias: alg_customer_customer_group_select }
+        - { name: form.type, alias: aligent_abn_customer_group_select }


### PR DESCRIPTION
This PR updates this bundle to follow Oro 4.2 standards by renaming the services and remove all class parameters from the services.yml. 