### PR TITLE
Oro 4.2 Compatibility Fix - Doctrine Dependency

### DIFF
--- a/src/Form/Type/CustomerGroupSelectType.php
+++ b/src/Form/Type/CustomerGroupSelectType.php
@@ -12,7 +12,7 @@
 
 namespace Aligent\ABNBundle\Form\Type;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Oro\Bundle\CustomerBundle\Entity\CustomerGroup;
 use Oro\Bundle\CustomerBundle\Entity\Repository\CustomerGroupRepository;
 


### PR DESCRIPTION
Resolves #10
    
Change `CustomerGroupSelectType` to use correct Doctrine `ManagerRegistry` path