### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "4.2.*"
+    "oro/commerce": "6.0.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^1.7",
-    "phpmd/phpmd": "^2.12",
-    "friendsofphp/php-cs-fixer": "~2.18.2 || ~3.1.0 || ~3.4.0",
-    "nelmio/alice": "~3.8.0 || ~3.9.0",
-    "theofidry/alice-data-fixtures": "~1.4.0 || ~1.5.0",
-    "symfony/phpunit-bridge": "~4.4.24 || ~6.1.0",
-    "squizlabs/php_codesniffer": "^3.6"
+    "phpstan/phpstan": "~1.10.0",
+    "phpmd/phpmd": "^2.15",
+    "friendsofphp/php-cs-fixer": "~2.18.2 || ~3.1.0 || ~3.57.0",
+    "nelmio/alice": "~3.8.0 || ~3.12.1",
+    "theofidry/alice-data-fixtures": "~1.4.0 || ~1.6.0",
+    "symfony/phpunit-bridge": "~4.4.24 || ~6.4.0",
+    "squizlabs/php_codesniffer": "~3.10.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/DependencyInjection/AligentABNExtension.php
+++ b/src/DependencyInjection/AligentABNExtension.php
@@ -33,10 +33,7 @@ class AligentABNExtension extends Extension
         $loader->load('services.yml');
     }
 
-    /**
-     * @return string
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return self::ALIAS;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,13 +26,11 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root(AligentABNExtension::ALIAS);
+        $treeBuilder = new TreeBuilder(AligentABNExtension::ALIAS);
+        $rootNode = $treeBuilder->getRootNode();
 
         SettingsBuilder::append(
             $rootNode,
@@ -46,12 +44,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-
-    /**
-     * @param string $key
-     * @return string
-     */
-    public static function getConfigKeyByName($key)
+    public static function getConfigKeyByName(string $key): string
     {
         return implode(ConfigManager::SECTION_MODEL_SEPARATOR, [AligentABNExtension::ALIAS, $key]);
     }

--- a/src/Form/EventListener/FrontendCustomerUserRegistrationTypeSubscriber.php
+++ b/src/Form/EventListener/FrontendCustomerUserRegistrationTypeSubscriber.php
@@ -13,33 +13,29 @@
 namespace Aligent\ABNBundle\Form\EventListener;
 
 use Aligent\ABNBundle\DependencyInjection\Configuration;
+use Oro\Bundle\ConfigBundle\Config\ConfigManager;
 use Oro\Bundle\CustomerBundle\Entity\Customer;
+use Oro\Bundle\CustomerBundle\Entity\CustomerGroup;
 use Oro\Bundle\CustomerBundle\Entity\CustomerUser;
 use Oro\Bundle\EntityBundle\ORM\Registry;
-use Oro\Bundle\ConfigBundle\Config\ConfigManager;
-use Oro\Bundle\CustomerBundle\Entity\CustomerGroup;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
 class FrontendCustomerUserRegistrationTypeSubscriber implements EventSubscriberInterface
 {
-    /** @var $registry Registry */
-    protected $registry;
+    protected Registry $registry;
 
-    /** @var ConfigManager  */
-    protected $configManager;
+    protected ConfigManager $configManager;
 
     /**
      * FrontendCustomerUserRegistrationTypeSubscriber constructor.
-     * @param Registry $registry
-     * @param ConfigManager $configManager
      */
     public function __construct(
         Registry $registry,
         ConfigManager $configManager
     ) {
-    
+
         $this->configManager = $configManager;
         $this->registry = $registry;
     }
@@ -47,17 +43,14 @@ class FrontendCustomerUserRegistrationTypeSubscriber implements EventSubscriberI
     /**
      * @inheritdoc
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::POST_SUBMIT => 'postSubmit'
         ];
     }
 
-    /**
-     * @param FormEvent $formEvent
-     */
-    public function postSubmit(FormEvent $formEvent)
+    public function postSubmit(FormEvent $formEvent): void
     {
         if ($this->configManager->get(Configuration::getConfigKeyByName(Configuration::ENABLED), false)) {
             /** @var CustomerUser $customerUser */
@@ -77,10 +70,8 @@ class FrontendCustomerUserRegistrationTypeSubscriber implements EventSubscriberI
 
     /**
      * Set the default group of the user if it is set and exists
-     * @param Customer $customer
-     * @param string $paramName
      */
-    protected function setDefaultGroup(Customer $customer, string $paramName)
+    protected function setDefaultGroup(Customer $customer, string $paramName): void
     {
         $groupId = $this->configManager->get(Configuration::getConfigKeyByName($paramName));
         if (isset($groupId)) {

--- a/src/Form/EventSubscriber/StripWhitespaceSubscriber.php
+++ b/src/Form/EventSubscriber/StripWhitespaceSubscriber.php
@@ -12,16 +12,13 @@
 
 namespace Aligent\ABNBundle\Form\EventSubscriber;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class StripWhitespaceSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @param FormEvent $event
-     */
-    public function onSubmit(FormEvent $event)
+    public function onSubmit(FormEvent $event): void
     {
         $data = $event->getData();
 
@@ -30,7 +27,7 @@ class StripWhitespaceSubscriber implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [FormEvents::SUBMIT => 'onSubmit'];
     }

--- a/src/Form/Extension/RegistrationTypeExtension.php
+++ b/src/Form/Extension/RegistrationTypeExtension.php
@@ -22,13 +22,11 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class RegistrationTypeExtension extends AbstractTypeExtension
 {
-    /** @var  EventSubscriberInterface */
-    protected $subscriber;
+    protected EventSubscriberInterface $subscriber;
 
-    /** @var ConfigManager */
-    protected $configManager;
+    protected ConfigManager $configManager;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->configManager->get(Configuration::getConfigKeyByName(Configuration::ENABLED), false)) {
             $builder->add('abn', ABNType::class, [
@@ -47,28 +45,22 @@ class RegistrationTypeExtension extends AbstractTypeExtension
      *
      * @return string The name of the type being extended
      */
-    public function getExtendedType()
+    public function getExtendedType(): string
     {
         return FrontendCustomerUserRegistrationType::class;
     }
 
-    /**
-     * @param EventSubscriberInterface $subscriber
-     */
-    public function setSubscriber(EventSubscriberInterface $subscriber)
+    public function setSubscriber(EventSubscriberInterface $subscriber): void
     {
         $this->subscriber = $subscriber;
     }
 
-    /**
-     * @param ConfigManager $configManager
-     */
-    public function setConfigManager(ConfigManager $configManager)
+    public function setConfigManager(ConfigManager $configManager): void
     {
         $this->configManager = $configManager;
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [
             FrontendCustomerUserRegistrationType::class,

--- a/src/Form/Type/ABNType.php
+++ b/src/Form/Type/ABNType.php
@@ -21,20 +21,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ABNType extends AbstractType
 {
-    /**
-     * @param FormBuilderInterface $builder
-     * @param array $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Strip all whitespace so ABN can be unique
         $builder->addEventSubscriber(new StripWhitespaceSubscriber());
     }
 
-    /**
-     * @param OptionsResolver $resolver
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'pattern' => '^(\d *?){11}$',
@@ -45,9 +38,9 @@ class ABNType extends AbstractType
     }
 
     /**
-     * @return string
+     * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }

--- a/src/Form/Type/CustomerGroupSelectType.php
+++ b/src/Form/Type/CustomerGroupSelectType.php
@@ -15,26 +15,20 @@ namespace Aligent\ABNBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Oro\Bundle\CustomerBundle\Entity\CustomerGroup;
 use Oro\Bundle\CustomerBundle\Entity\Repository\CustomerGroupRepository;
-
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomerGroupSelectType extends AbstractType
 {
-    /** @var ManagerRegistry */
-    protected $registry;
+    protected ManagerRegistry $registry;
 
-    /**
-     * @param ManagerRegistry $registry
-     */
     public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;
     }
 
-
-    public function getName()
+    public function getName(): string
     {
         return 'aligent_abn_customer_group_select';
     }
@@ -42,7 +36,7 @@ class CustomerGroupSelectType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefault('placeholder', 'aligent.abn.form.group_choice.placeholder');
         $resolver->setNormalizer(
@@ -65,7 +59,7 @@ class CustomerGroupSelectType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Migration/RemoveFieldQuery.php
+++ b/src/Migration/RemoveFieldQuery.php
@@ -20,15 +20,14 @@ use Psr\Log\LoggerInterface;
 
 class RemoveFieldQuery extends BaseRemoveFieldQuery
 {
-
-    public function execute(LoggerInterface $logger)
+    public function execute(LoggerInterface $logger): void
     {
         parent::execute($logger);
 
         $this->removeEntityConfig($logger);
     }
 
-    protected function removeEntityConfig($logger)
+    protected function removeEntityConfig($logger): void
     {
         $entityRow = $this->getEntityRow($this->entityClass);
         if (!$entityRow) {
@@ -54,12 +53,7 @@ class RemoveFieldQuery extends BaseRemoveFieldQuery
         $this->updateEntityData($logger, $entityData, $this->entityClass);
     }
 
-    /**
-     * @param string $entityClass
-     *
-     * @return array
-     */
-    protected function getEntityRow($entityClass)
+    protected function getEntityRow(string $entityClass): array
     {
         $getEntitySql = 'SELECT e.data 
                 FROM oro_entity_config as e 
@@ -73,17 +67,13 @@ class RemoveFieldQuery extends BaseRemoveFieldQuery
     }
 
     /**
-     * @param LoggerInterface $logger
-     * @param array           $entityData
-     * @param string          $entityClass
-     *
      * @throws DBALException
      */
     protected function updateEntityData(
         LoggerInterface $logger,
-        $entityData,
-        $entityClass
-    ) {
+        array $entityData,
+        string $entityClass
+    ): void {
 
         $data = $this->connection->convertToDatabaseValue($entityData, Type::TARRAY);
 

--- a/src/Migrations/Schema/AligentABNBundleInstaller.php
+++ b/src/Migrations/Schema/AligentABNBundleInstaller.php
@@ -7,6 +7,7 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
+
 namespace Aligent\ABNBundle\Migrations\Schema;
 
 use Doctrine\DBAL\Schema\Schema;
@@ -20,7 +21,7 @@ class AligentABNBundleInstaller implements Installation
     /**
      * @inheritDoc
      */
-    public function getMigrationVersion()
+    public function getMigrationVersion(): string
     {
         return 'v1_3';
     }
@@ -28,7 +29,7 @@ class AligentABNBundleInstaller implements Installation
     /**
      * @inheritDoc
      */
-    public function up(Schema $schema, QueryBag $queries)
+    public function up(Schema $schema, QueryBag $queries): void
     {
         $table = $schema->getTable('oro_customer');
 

--- a/src/Migrations/Schema/v1_0/AddABNToCustomer.php
+++ b/src/Migrations/Schema/v1_0/AddABNToCustomer.php
@@ -20,17 +20,13 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
 class AddABNToCustomer implements Migration
 {
-
     /**
      * Modifies the given schema to apply necessary changes of a database
      * The given query bag can be used to apply additional SQL queries before and after schema changes
      *
-     * @param Schema $schema
-     * @param QueryBag $queries
-     * @return void
      * @throws \Doctrine\DBAL\Schema\SchemaException
      */
-    public function up(Schema $schema, QueryBag $queries)
+    public function up(Schema $schema, QueryBag $queries): void
     {
         $table = $schema->getTable('oro_customer');
 

--- a/src/Migrations/Schema/v1_1/MakeABNUnique.php
+++ b/src/Migrations/Schema/v1_1/MakeABNUnique.php
@@ -18,16 +18,11 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
 class MakeABNUnique implements Migration
 {
-
     /**
      * Modifies the given schema to apply necessary changes of a database
      * The given query bag can be used to apply additional SQL queries before and after schema changes
-     *
-     * @param Schema $schema
-     * @param QueryBag $queries
-     * @return void
      */
-    public function up(Schema $schema, QueryBag $queries)
+    public function up(Schema $schema, QueryBag $queries): void
     {
         // Removed unique index on ABN as all clients have requested this
         // This migration is for reference only now

--- a/src/Migrations/Schema/v1_2/AlterABNColumn.php
+++ b/src/Migrations/Schema/v1_2/AlterABNColumn.php
@@ -20,16 +20,11 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
 class AlterABNColumn implements Migration
 {
-
     /**
      * Modifies the given schema to apply necessary changes of a database
      * The given query bag can be used to apply additional SQL queries before and after schema changes
-     *
-     * @param Schema $schema
-     * @param QueryBag $queries
-     * @return void
      */
-    public function up(Schema $schema, QueryBag $queries)
+    public function up(Schema $schema, QueryBag $queries): void
     {
         $table = $schema->getTable('oro_customer');
 

--- a/src/Migrations/Schema/v1_3/DropABNColumn.php
+++ b/src/Migrations/Schema/v1_3/DropABNColumn.php
@@ -20,16 +20,11 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
 class DropABNColumn implements Migration
 {
-
     /**
      * Modifies the given schema to apply necessary changes of a database
      * The given query bag can be used to apply additional SQL queries before and after schema changes
-     *
-     * @param Schema $schema
-     * @param QueryBag $queries
-     * @return void
      */
-    public function up(Schema $schema, QueryBag $queries)
+    public function up(Schema $schema, QueryBag $queries): void
     {
         $table = $schema->getTable('oro_customer');
         $table->dropColumn('abn');

--- a/src/Tests/Unit/DependencyInjection/AligentABNExtensionTest.php
+++ b/src/Tests/Unit/DependencyInjection/AligentABNExtensionTest.php
@@ -7,12 +7,13 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
+
 namespace Aligent\ABNBundle\Tests\Unit\DependencyInjection;
 
+use Aligent\ABNBundle\DependencyInjection\AligentABNExtension;
 use Aligent\ABNBundle\Form\EventListener\FrontendCustomerUserRegistrationTypeSubscriber;
 use Aligent\ABNBundle\Form\Extension\RegistrationTypeExtension;
 use Aligent\ABNBundle\Form\Type\CustomerGroupSelectType;
-use Aligent\ABNBundle\DependencyInjection\AligentABNExtension;
 use Oro\Bundle\TestFrameworkBundle\Test\DependencyInjection\ExtensionTestCase;
 
 class AligentABNExtensionTest extends ExtensionTestCase

--- a/src/Validator/Constraints/ABNValidator.php
+++ b/src/Validator/Constraints/ABNValidator.php
@@ -12,9 +12,9 @@
 
 namespace Aligent\ABNBundle\Validator\Constraints;
 
+use Oro\Bundle\EntityExtendBundle\EntityPropertyInfo;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class ABNValidator extends ConstraintValidator
@@ -29,7 +29,7 @@ class ABNValidator extends ConstraintValidator
      * @param mixed $value The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      */
-    public function validate($value, Constraint $constraint)
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof ABN) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\ABN');
@@ -39,7 +39,7 @@ class ABNValidator extends ConstraintValidator
             return;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+        if (!is_scalar($value) && !(is_object($value) && EntityPropertyInfo::methodExists($value, '__toString'))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 
@@ -49,7 +49,7 @@ class ABNValidator extends ConstraintValidator
         $abn = preg_replace("/\s+/", "", $value);
 
         // check length is 11 digits
-        if (strlen($abn)==11) {
+        if (strlen($abn) == 11) {
             // apply ato check method
             $sum = 0;
             foreach (static::WEIGHTS as $position => $weight) {


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/platform 6.0.*
- Added return types/type hints
- Deleted not needed annotations
- Added some CS fixes
